### PR TITLE
QuickFix for OAth version: 5.2.7

### DIFF
--- a/src/yubi.py
+++ b/src/yubi.py
@@ -28,7 +28,7 @@ def execute(cmd_list):
 
 def get_all_codes():
     formatted_codes = []
-    codes = execute(['ykman', 'oath', 'code']).splitlines()
+    codes = execute(['ykman', 'oath', 'accounts', 'code']).splitlines()
     for code in codes:
         log.info(code)
         code_search = re.search('(.*)((\d{6,8})|(\[Touch))', code, re.IGNORECASE)


### PR DESCRIPTION
Issue - https://github.com/robertoriv/alfred-yubikey-otp/issues/6 

When using the latest oath version, the old command (`ykman oath code`) is deprecated and due the warning message the workflow is broken :

The fix is using the new command:

```
ykman oath accounts code
```

