### PR TITLE
Modify conditional regex to match only full strings so that keys with 6 or 8 decimal numbers work properly

### DIFF
--- a/src/info.plist.template
+++ b/src/info.plist.template
@@ -179,7 +179,7 @@
 						<key>matchmode</key>
 						<integer>4</integer>
 						<key>matchstring</key>
-						<string>(\d{6,8})</string>
+						<string>^(\d{6,8})$</string>
 						<key>outputlabel</key>
 						<string>Code</string>
 						<key>uid</key>


### PR DESCRIPTION
**Issue**

When a key name contains a number with six or eight digits, the conditional step in the workflow matches these digits and bypasses touching and obtaining the code from the yubikey and instead copies the key (not the code).

*E.g*: I want to obtain a code for an app "Sample App Account no. 123456-abc". When I select this entry and press enter, I am not required to touch my yubikey, but the string `Sample App Account no. 123456-abc` is copied to the clipboard instead because the conditional step matches `123456` and mistakes it for a OTP code. I cannot access a code for this key via the workflow at all.

**Suggested solution**

Instead of just checking that the value contains six or eight digits, the conditional should probably check that the value **only** consists of those digits and nothing else.
This is achieved by making the regex match not only the digits but the whole string, using `^` and `$`.

Even though this is a small change, please review it carefully, since I am not sure that I am aware of all the use cases for the conditional.

BTW, thanks for this awesome workflow, I have been using it for a few months now and apart from this small issue, it's been a great help! :)